### PR TITLE
routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "object-assign": "^4.0.1",
     "redux": "^3.0.0",
     "request": "^2.69.0",
+    "sheet-router": "^2.0.5",
     "shelljs": "^0.6.0",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5"

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,10 @@ app.get('/', function (req, res) {
   return res.sendFile(path.join(staticPath, 'index.html'))
 })
 
+app.get('/status/:project/:repo', function (req, res) {
+  return res.sendFile(path.join(staticPath, 'index.html'))
+})
+
 app.get('/logs/:templateName/:startTime', function (req, res) {
   return res.sendFile(path.join(staticPath, 'logs.html'))
 })

--- a/site/components/detail/back.js
+++ b/site/components/detail/back.js
@@ -1,10 +1,12 @@
 var hx = require('hxdx').hx
 var dx = require('hxdx').dx
+var href = require('sheet-router/href')
+var router = require('../../router')
 var actions = require('../../reducers/actions')
 
 module.exports = function () {
   function onclick () {
-    actions.showOverview()(dx)
+    href(function (link) {router(link)})
   }
 
   var style = {

--- a/site/components/detail/back.js
+++ b/site/components/detail/back.js
@@ -40,6 +40,6 @@ module.exports = function () {
   return hx`
   <div style=${style.container}>
     <img style=${style.icon} src='/assets/images/back.svg'>
-    <button style=${style.button} className='button' onclick=${onclick}>go back</button>
+    <a href='/'><button style=${style.button} className='button' onclick=${onclick}>go back</button></a>
   </div>`
 }

--- a/site/components/detail/index.js
+++ b/site/components/detail/index.js
@@ -10,6 +10,7 @@ var template = require('./template')
 var info = require('./info')
 
 var detail = function (state) {
+
   var style = {
     container: {
       width: '100%',
@@ -27,19 +28,31 @@ var detail = function (state) {
   var id = state.selection
   var item = state.entries[id]
 
-  return hx`
-  <div style=${style.container}>
-    <div style=${style.top}>
-      ${back()}
-      ${info(item)}
-      ${more()}
+  if (!item) {
+    return hx`
+    <div style=${style.container}>
+      <div style=${style.top}>
+        <div style='text-align: center'>
+          <div style='margin-top: 175px;' className='three-quarters-loader'></div>
+        </div>
+      </div>
     </div>
-    <div style=${style.bottom}>
-      ${progress(item)}
-      ${logs(item)}
-      ${badge(item)}
-    </div>
-  </div>`
+    `
+  } else {
+    return hx`
+    <div style=${style.container}>
+      <div style=${style.top}>
+        ${back()}
+        ${info(item)}
+        ${more()}
+      </div>
+      <div style=${style.bottom}>
+        ${progress(item)}
+        ${logs(item)}
+        ${badge(item)}
+      </div>
+    </div>`
+  }
 }
 
 module.exports = connect({ 

--- a/site/components/overview/binder.js
+++ b/site/components/overview/binder.js
@@ -1,12 +1,14 @@
 var hx = require('hxdx').hx
 var dx = require('hxdx').dx
 var actions = require('../../reducers/actions')
+var href = require('sheet-router/href')
+var router = require('../../router')
 var theme = require('../../theme')
 
 module.exports = function (entry) {
 
   function onclick () {
-    actions.showDetail(entry.name, entry.build['start-time'])(dx)
+    href(function (link) {router(link)})
   }
 
   var color = function (status) {

--- a/site/components/overview/binder.js
+++ b/site/components/overview/binder.js
@@ -93,7 +93,7 @@ module.exports = function (entry) {
 
   return hx`
   <div style=${style.container}>
-    <div style=${style.name} className='label' onclick=${onclick}>${displayName()}</div>
+    <a href=${'/status/' + displayName()}><div style=${style.name} className='label' onclick=${onclick}>${displayName()}</div></a>
     <div style=${style.group}>
       <span style=${style.deployed}>${entry.deployed}</span>
       <span style=${style.status}></span>

--- a/site/index.js
+++ b/site/index.js
@@ -4,20 +4,9 @@ var reducer = require('./reducers')
 var initial = require('./reducers/initial')
 var actions = require('./reducers/actions')
 var components = require('./components')
-var sheetRouter = require('sheet-router')
+var router = require('./router')
 
 var store = createStore(reducer, initial)
 hxdx.render(components, store)
-
-var router = sheetRouter('/', function (route) {
-  return [
-    route('/', function (params){ 
-      actions.showOverview()(hxdx.dx)
-    }),
-    route('/status/:project/:repo', function (params) {
-      actions.showDetail(params.project + '-' + params.repo)(hxdx.dx)
-    })
-  ]
-})
 
 router(window.location.pathname)

--- a/site/index.js
+++ b/site/index.js
@@ -3,12 +3,21 @@ var createStore = require('redux').createStore
 var reducer = require('./reducers')
 var initial = require('./reducers/initial')
 var actions = require('./reducers/actions')
-var dev = window.devToolsExtension ? window.devToolsExtension() : undefined
 var components = require('./components')
+var sheetRouter = require('sheet-router')
 
-var store = createStore(reducer, initial, dev)
+var store = createStore(reducer, initial)
 hxdx.render(components, store)
 
-var id = window.location.pathname.replace('/repo/', '').replace('/status', '')
+var router = sheetRouter('/', function (route) {
+  return [
+    route('/', function (params){ 
+      actions.showOverview()(hxdx.dx)
+    }),
+    route('/status/:project/:repo', function (params) {
+      actions.showDetail(params.project + '-' + params.repo)(hxdx.dx)
+    })
+  ]
+})
 
-actions.showOverview()(hxdx.dx)
+router(window.location.pathname)

--- a/site/router.js
+++ b/site/router.js
@@ -1,0 +1,14 @@
+var hxdx = require('hxdx')
+var actions = require('./reducers/actions')
+var sheetRouter = require('sheet-router')
+
+module.exports = sheetRouter('/', function (route) {
+  return [
+    route('/', function (params){ 
+      actions.showOverview()(hxdx.dx)
+    }),
+    route('/status/:project/:repo', function (params) {
+      actions.showDetail(params.project + '-' + params.repo)(hxdx.dx)
+    })
+  ]
+})


### PR DESCRIPTION
This PR is meant to add basic client-side routing. The three things we need are:
- visiting `/status/project/repo` directly should bring up the detail page for a binder
- clicking on a binder from the main page should set the url to `/status/project/repo`
- clicking back on a detail view should return to the overview page and set the url to `/`

In the current version with `sheet-router`, all three behaviors work as desired, but there is an annoying "flash" due to what seems like an unintended page refresh. Need to get rid of this!
