### PR TITLE
Enable cors on deploy and apps

### DIFF
--- a/conf/cors.json
+++ b/conf/cors.json
@@ -1,0 +1,4 @@
+{
+    "origin": "*",
+    "optionsSuccessStatus": 200
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "brfs": "^1.4.3",
     "browser-request": "^0.3.3",
     "browserify": "^13.0.0",
+    "cors": "^2.8.1",
     "date-and-time": "^0.3.0",
     "dom-css": "^2.0.0",
     "envify": "^3.4.1",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,17 +1,29 @@
 var fs = require('fs')
 var path = require('path')
 
-var fileName = 'web.conf'
+var fileName1 = 'web.conf'
+var fileName2 = 'cors.conf'
 
 var binderDir = path.join(process.env['HOME'], '.binder')
-var src = path.join(__dirname, '../conf/main.json')
-var dst = path.join(binderDir, fileName)
+
+var src1 = path.join(__dirname, '..', 'conf', 'main.json')
+var dst1 = path.join(binderDir, fileName1)
+
+var src2 = path.join(__dirname, '..', 'conf', 'cors.json')
+var dst2 = path.join(binderDir, fileName2)
 
 var dirExists = fs.existsSync(binderDir)
-var fileExists = fs.existsSync(dst)
+var fileExists1 = fs.existsSync(dst1)
+var fileExists2 = fs.existsSync(dst2)
+
 if (!dirExists) {
   fs.mkdirSync(binderDir)
 }
-if (!fileExists) {
-  fs.createReadStream(src).pipe(fs.createWriteStream(dst))
+
+if (!fileExists1) {
+  fs.createReadStream(src1).pipe(fs.createWriteStream(dst1))
+}
+
+if (!fileExists2) {
+  fs.createReadStream(src2).pipe(fs.createWriteStream(dst2))
 }

--- a/server/cors-settings.js
+++ b/server/cors-settings.js
@@ -1,0 +1,5 @@
+var path = require('path')
+var fs = require('fs')
+
+var contents = fs.readFileSync(path.join(process.env['HOME'], '.binder', 'cors.conf'), 'utf8')
+module.exports = JSON.parse(contents)

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ var expressWs = require('express-ws')
 var bodyParser = require('body-parser')
 var app = express()
 var http = require('http').Server(app)
+var cors = require('cors');
 var io = require('socket.io')(http)
 var assign = require('object-assign')
 var merge = require('lodash.merge')
@@ -19,6 +20,10 @@ app.use(bodyParser.json())
 app.use('/js', express.static(path.join(__dirname, '../public/js')))
 app.use('/css', express.static(path.join(__dirname, '../public/css')))
 app.use('/assets', express.static(path.join(__dirname, '../public/assets')))
+
+// CORS options
+
+var launchCORSOptions = require('./cors-settings')
 
 // set once the server is started
 var binder = null
@@ -63,7 +68,7 @@ app.get('/validate/:name', function (req, res) {
 
 // API endpoints
 
-app.get('/api/deploy/:templateName', function (req, res) {
+app.get('/api/deploy/:templateName', cors(launchCORSOptions), function (req, res) {
   var name = req.params.templateName
   binder.deployBinder(name, function (err, status) {
     if (err) return res.status(500).end()
@@ -71,7 +76,7 @@ app.get('/api/deploy/:templateName', function (req, res) {
   })
 })
 
-app.get('/api/apps/:templateName/:id', function (req, res) {
+app.get('/api/apps/:templateName/:id', cors(launchCORSOptions), function (req, res) {
   var name = req.params.templateName
   var id = req.params.id
   binder.getDeployStatus(name, id, function (err, status) {


### PR DESCRIPTION
Tackling https://github.com/binder-project/binder/issues/93 and https://github.com/binder-project/binder/issues/9

CORS settings for `deploy` and `apps` can be setup with a `cors.conf` file in `.binder` right by `web.conf`.