### PR TITLE
fix github examples link

### DIFF
--- a/site/components/overview/guide.js
+++ b/site/components/overview/guide.js
@@ -82,7 +82,7 @@ module.exports = function () {
     <div style=${styles.step}>
       <div style=${styles.label}><span style=${assign(styles.red, styles.number)}>2</span></div>
       <div style=${styles.description}>
-        <h2 style=${styles.medium}>We’ll search your repository for dependency files, in the following preference order: Dockerfile, requirements.txt (for Python), environment.yml (for Conda). The first one found will be used to build an image. See the <a href='https://github.com/binder-project?query=example' className='welcome-link'>examples</a> for different kinds of builds.</h2>
+        <h2 style=${styles.medium}>We’ll search your repository for dependency files, in the following preference order: Dockerfile, requirements.txt (for Python), environment.yml (for Conda). The first one found will be used to build an image. See the <a href='https://github.com/binder-project?q=example' className='welcome-link'>examples</a> for different kinds of builds.</h2>
       </div>
     </div>
     <div style=${styles.step}>

--- a/site/components/overview/welcome.js
+++ b/site/components/overview/welcome.js
@@ -22,7 +22,7 @@ module.exports = function () {
   <div style=${styles.container}>
     <h1 style=${styles.big}>Turn a GitHub repo into a collection of interactive notebooks</h1>
     <h2 style=${styles.medium}>Have a repository full of Jupyter notebooks? With Binder, you can add a badge that opens those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.</h2>
-    <h2 style=${styles.medium}>100% free and <a className='welcome-link' href='https://github.com/binder-project'>open source</a>. Browse <a className='welcome-link' href='https://github.com/binder-project?query=example'>examples</a>. Read the <a className='welcome-link' href='http://docs.mybinder.org/faq'>FAQ</a>.</h2>
+    <h2 style=${styles.medium}>100% free and <a className='welcome-link' href='https://github.com/binder-project'>open source</a>. Browse <a className='welcome-link' href='https://github.com/binder-project?q=example'>examples</a>. Read the <a className='welcome-link' href='http://docs.mybinder.org/faq'>FAQ</a>.</h2>
   </div>
   `
 }


### PR DESCRIPTION
The link for example binders in the front page points here:

https://github.com/binder-project?query=example

but it should link to

https://github.com/binder-project?q=example

I'm not sure what the newline change is at the bottom of the file, github changed that automatically somehow