### PR TITLE
Added async@1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/binder-project/binder-web/issues"
   },
   "dependencies": {
+    "async": "^1.5.2",
     "binder-client": "^1.0.1",
     "binder-logging": "^1.0.0",
     "binder-utils": "^1.0.0",


### PR DESCRIPTION
`async` hasn't been an explicit dependency of binder-web, but the typical way we'd start the service is through [binder-control](https://github.com/binder-project/binder-control), which includes a version of `async` that was being browserified.

`async@1.0.0` appears to have different `retry` semantics, and was breaking [`binder-deployment`](https://www.github.com/yuvipanda/binder-deployment). This PR pins `async` to a known working version.